### PR TITLE
Drastically reduced loading by paginating + loaded in recipients names

### DIFF
--- a/src/components/BridgeMonitor.jsx
+++ b/src/components/BridgeMonitor.jsx
@@ -13,25 +13,44 @@ class BridgeMonitor extends Component {
   constructor(props) {
     super(props);
 
-    const socket = io(config.feathersConnection);
-    const client = feathers();
-    client.configure(
-      feathers.socketio(socket, { timeout: 30000, pingTimeout: 30000, upgradeTimeout: 30000 }),
+    // Bridge feathers
+    const bridge_socket = io(config.feathersConnection);
+    const bridge_client = feathers();
+    bridge_client.configure(
+      feathers.socketio(bridge_socket, {
+        timeout: 30000,
+        pingTimeout: 30000,
+        upgradeTimeout: 30000
+      })
     );
+
+    // Dapp feathers
+    const dapp_socket = io(config.feathersDappConnection);
+    const dapp_client = feathers();
+    dapp_client.configure(
+      feathers.socketio(dapp_socket, {
+        timeout: 30000,
+        pingTimeout: 30000,
+        upgradeTimeout: 30000
+      })
+    );
+
     this.state = {
-      client,
+      bridge_client,
+      dapp_client,
       donations: [],
       deposits: [],
       withdrawals: [],
       payments: [],
       info: {},
+      recipients: {}
     };
-    client
+    bridge_client
       .service('information')
       .find()
       .then(info => {
         this.setState({
-          info,
+          info
         });
       });
 
@@ -39,14 +58,14 @@ class BridgeMonitor extends Component {
   }
 
   loadEvents = async () => {
-    const client = this.state.client;
+    const client = this.state.bridge_client;
 
     client
       .service('donations')
       .find()
       .then(donations => {
         this.setState({
-          donations: donations.data,
+          donations: donations.data
         });
       });
 
@@ -55,7 +74,7 @@ class BridgeMonitor extends Component {
       .find()
       .then(deposits => {
         this.setState({
-          deposits: deposits.data,
+          deposits: deposits.data
         });
       });
 
@@ -64,7 +83,7 @@ class BridgeMonitor extends Component {
       .find()
       .then(withdrawals => {
         this.setState({
-          withdrawals: withdrawals.data,
+          withdrawals: withdrawals.data
         });
       });
 
@@ -72,11 +91,37 @@ class BridgeMonitor extends Component {
       .service('payments')
       .find()
       .then(payments => {
+        var data = payments.data;
+        var recipients = [];
+        data.forEach(element => {
+          if (element.event.returnValues) {
+            var recipient = element.event.returnValues.recipient;
+            if (!recipients.includes(recipient)) {
+              recipients.push(recipient);
+              this.state.dapp_client
+                .service('users')
+                .find({
+                  query: {
+                    address: recipient
+                  }
+                })
+                .then(result => {
+                  let r = Object.assign({}, this.state.recipients);
+                  console.log(result.data);
+                  if (result.data.length > 0 && result.data[0].name) {
+                    r[recipient] = result.data[0].name;
+                    this.setState({ recipients: r });
+                    console.log(r);
+                  }
+                });
+            }
+          }
+        });
         this.setState({
-          payments: payments.data,
+          payments: payments.data
         });
       });
-    setTimeout(this.loadEvents, 5000);
+    setTimeout(this.loadEvents, 1000 * 60 * 5);
   };
 
   render() {
@@ -85,14 +130,19 @@ class BridgeMonitor extends Component {
         <Tabs forceRenderTabPanel={true}>
           <TabList>
             <Tab>Authorized Payments</Tab>
-            <Tab>{config.homeNetworkName + " -> " + config.foreignNetworkName}</Tab>
-            <Tab>{config.foreignNetworkName + " -> " + config.homeNetworkName}</Tab>
+            <Tab>
+              {config.homeNetworkName + " -> " + config.foreignNetworkName}
+            </Tab>
+            <Tab>
+              {config.foreignNetworkName + " -> " + config.homeNetworkName}
+            </Tab>
             <Tab> Info and Utilities </Tab>
           </TabList>
 
           <TabPanel>
             <div>
               <PaymentsTable
+                recipients={this.state.recipients}
                 payments={this.state.payments}
                 lastCheckin={this.state.info.securityGuardLastCheckin}
               />
@@ -101,7 +151,7 @@ class BridgeMonitor extends Component {
 
           <TabPanel>
             <div className="flex_container">
-            <div className="column">
+              <div className="column">
                 <EventTable
                   events={this.state.donations}
                   header={config.homeNetworkName + " Deposits"}
@@ -109,8 +159,8 @@ class BridgeMonitor extends Component {
                   duplicateTable={true}
                   etherscanURL={config.homeEtherscanURL}
                 />
-            </div>
-            <div className="column">
+              </div>
+              <div className="column">
                 <EventTable
                   events={this.state.deposits}
                   header={config.foreignNetworkName + " Deposits"}
@@ -119,8 +169,6 @@ class BridgeMonitor extends Component {
                   etherscanURL={config.foreignEtherscanURL}
                 />
               </div>
-              
-              
             </div>
           </TabPanel>
 
@@ -134,7 +182,7 @@ class BridgeMonitor extends Component {
                   duplicateTable={true}
                   etherscanURL={config.foreignEtherscanURL}
                 />
-              </div> 
+              </div>
               <div className="column">
                 <EventTable
                   events={this.state.payments}
@@ -146,9 +194,12 @@ class BridgeMonitor extends Component {
               </div>
             </div>
           </TabPanel>
-          
+
           <TabPanel>
-            <Info client={this.state.client} contracts={this.state.info} />
+            <Info
+              client={this.state.bridge_client}
+              contracts={this.state.info}
+            />
           </TabPanel>
         </Tabs>
       </div>

--- a/src/components/PaymentsTable.jsx
+++ b/src/components/PaymentsTable.jsx
@@ -94,7 +94,7 @@ class PaymentsTable extends Component {
           {
             id: 'recipient',
             Header: 'Recipient',
-            accessor: datum => datum.event.returnValues.recipient,
+            accessor: datum => this.props.recipients.hasOwnProperty(datum.event.returnValues.recipient) ? this.props.recipients[datum.event.returnValues.recipient] : datum.event.returnValues.recipient
           },
           {
             id: 'amount',

--- a/src/components/PaymentsTable.jsx
+++ b/src/components/PaymentsTable.jsx
@@ -10,6 +10,12 @@ client.configure(feathers.socketio(io(config.feathersDappConnection)));
 
 
 class PaymentsTable extends Component {
+  
+  componentDidMount() {
+    this.page = 0;
+    this.pageSize = 10;
+  }
+
   getRowColor = row => {
     let color;
     const status = this.getStatus(row.original);
@@ -94,7 +100,7 @@ class PaymentsTable extends Component {
           {
             id: 'recipient',
             Header: 'Recipient',
-            accessor: datum => this.props.recipients.hasOwnProperty(datum.event.returnValues.recipient) ? this.props.recipients[datum.event.returnValues.recipient] : datum.event.returnValues.recipient
+            accessor: datum => (this.props.recipients.hasOwnProperty(datum.event.returnValues.recipient) ? this.props.recipients[datum.event.returnValues.recipient] : "Unknown") + " - " + datum.event.returnValues.recipient
           },
           {
             id: 'amount',
@@ -151,10 +157,24 @@ class PaymentsTable extends Component {
             flexGrow={1}
             data={this.props.payments}
             columns={columns}
-            showPagination={false}
+            showPagination={true}
+            showPaginationBottom={true}
+            defaultPageSize={10}
+            onPageChange={page => {
+              if(page > this.page){
+                this.props.fetchPayments(page, this.pageSize);
+              }
+              this.page = page;
+            }}
+            onPageSizeChange={pageSize => {
+              if(pageSize > this.pageSize){
+                this.props.fetchPayments(this.page, pageSize);
+              }
+              this.pageSize = pageSize;
+            }}
             sortable={true}
             filterable={true}
-            pageSize={this.props.payments.length}
+            //pageSize={this.props.payments.length}
             getTrProps={this.getTrProps}
             collapseOnDataChange={false}
             defaultSorted={[


### PR DESCRIPTION
Fixes #16 & #12 

General and performance improvements, as discussed with @bowensanders 

Furthermore, reduces the reloading of data to every 5 minutes instead of 5 seconds (also for performance).